### PR TITLE
Validação de placa de veículo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ org
 
 * telefone_com_ddd - Valida um telefone através do formato (99)9999-9999
 
+* formato_placa_de_veiculo - Valida se a placa de veículo está no formato válido
+
 
 Então, podemos usar um simples teste:
 

--- a/src/pt-br-validator/Validator.php
+++ b/src/pt-br-validator/Validator.php
@@ -216,4 +216,17 @@ class Validator extends BaseValidator
         return preg_match('/^\d{2}\.?\d{3}-\d{3}$/', $value) > 0;
     }
 
+    /**
+     * Valida se o formato de placa de veículo está correto.
+     *
+     * @param string $attribute
+     * @param string $value
+     * @return boolean
+     */
+
+    public function validateFormatoPlacaDeVeiculo($attribute, $value)
+    {
+        return preg_match('/^[a-zA-Z]{3}\-?[0-9]{4}$/', $value) > 0;
+    }
+
 }

--- a/src/pt-br-validator/ValidatorProvider.php
+++ b/src/pt-br-validator/ValidatorProvider.php
@@ -48,7 +48,8 @@ class ValidatorProvider extends ServiceProvider
             'formato_cpf'      => 'O campo :attribute não possui o formato válido de CPF',
             'telefone'         => 'O campo :attribute não é um telefone válido',
             'telefone_com_ddd' => 'O campo :attribute não é um possui o formato válido de telefone com DDD',
-            'formato_cep'      => 'O campo :attribute não possui um formato válido de CEP'
+            'formato_cep'      => 'O campo :attribute não possui um formato válido de CEP',
+            'formato_placa_de_veiculo'   => 'O campo :attribute não possui um formato válido de placa',
         ];
     }
 

--- a/tests/TestValidator.php
+++ b/tests/TestValidator.php
@@ -247,4 +247,47 @@ class TestValidator extends Orchestra\Testbench\TestCase
         }
     }
 
+    public function testFormatoPlacaDeVeiculo()
+    {
+        $placasValidas = [
+            'ABC-1234',
+            'abc-1234',
+            'ABC1234',
+            'aBc1234', 
+            'abc1234'
+        ];
+
+        foreach ($placasValidas as $placa) {
+            
+            $correct = \Validator::make(
+                ['placa' => $placa], 
+                ['placa' => 'formato_placa_de_veiculo']
+            );
+
+            $this->assertTrue($correct->passes());
+        }
+
+        $placasInvalidas = [
+            'a2c-1234',
+            'abc-12ed',
+            'abc 1234',
+            'ãBC1234',
+            'ABCD1234',
+            'ABC12345',
+            'ab1234',
+            'ab123a4',
+            'abc+1234'
+        ];
+
+        foreach ($placasInvalidas as $placa) {
+            
+            $correct = \Validator::make(
+                ['placa' => $placa], 
+                ['placa' => 'formato_placa_de_veiculo']
+            );
+
+            $this->assertTrue($correct->fails());
+        }
+    }
+
 }


### PR DESCRIPTION
Adicionado o suporte à validação para placas de veículos no padrão brasileiro, como indicado em #5 .

Os formatos válidos são:

-  `AAA-9999`;
-  `aaa-9999`;
-  `AAA9999`;
-  `aaa9999`;

Ou seja, insensível às maiúsculas com o hífen opcional.