### PR TITLE
Laravel Package Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,12 @@
             "LaravelLegends\\PtBrValidator\\": "src/pt-br-validator"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "LaravelLegends\\PtBrValidator\\ValidatorProvider"
+            ]
+    },
     "minimum-stability": "stable",
     "require-dev": {
         "orchestra/testbench": "3.1.*",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
             "providers": [
                 "LaravelLegends\\PtBrValidator\\ValidatorProvider"
             ]
+        }
     },
     "minimum-stability": "stable",
     "require-dev": {


### PR DESCRIPTION
Since Laravel 5.5, it supports Package Discovery, so we don't need to add any class for `app.php`, this PR add this feature.