### PR TITLE
Support Laravel 5 major version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
+        "illuminate/support": "5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Voltando composer.json

Até o momento o Laravel já está em sua versão 5.8 e a biblioteca continua funcionando perfeitamente, mas a dependência está específica para para até a versão 5.5, e assim o composer acaba instalando a versão 5.1.3, aonde a dependência estava ainda estava aberta para toda a major version 5.*