### PR TITLE
Adicionada compatibilidade com o Laravel 6.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*"
+        "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -18,7 +18,7 @@
     },
     "minimum-stability": "stable",
     "require-dev": {
-        "orchestra/testbench": "3.1.*",
-        "phpunit/phpunit": "4.8.*"
+        "orchestra/testbench": "3.1.* || 4.0.*",
+        "phpunit/phpunit": "4.8.* || ^8.0"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/tests/ValidatorTestCase.php
+++ b/tests/ValidatorTestCase.php
@@ -2,7 +2,7 @@
 
 abstract class ValidatorTestCase extends Orchestra\Testbench\TestCase
 {
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 


### PR DESCRIPTION
1. Testes passando.
![image](https://user-images.githubusercontent.com/4139808/65998205-37326e00-e471-11e9-8230-de35718bebb1.png)

2. A configuração do PHPUnit `syntaxCheck` foi removida devido ao warning gerado, já que [segundo o criador do PHP Unit](https://stackoverflow.com/questions/44328114/phpunit-what-does-syntaxcheck-configuration-parameter-stands-for-exactly/44331140#44331140) ela já estava em desuso há algum tempo.

```
➜  pt-br-validator git:(master) ✗ vendor/bin/phpunit
PHPUnit 8.3.5 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 12:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.


............                                                      12 / 12 (100%)

Time: 108 ms, Memory: 12.00 MB

OK (12 tests, 55 assertions)
```

3. Uma declaração de tipo de retorno precisou ser adicionada ao método setup nos testes, caso contrário haveria uma quebra na herança. Por conta disso, a versão mínima do PHP para utilização do pacote deve ser 7.1+.

4. O pacote foi testado em um projeto com Laravel 6.1 e Laravel 5.6 e funcionou perfeitamente.


