### PR TITLE
Muda versao do iluminate para suportar a partir a versao 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^6.0"
+        "illuminate/support": "^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Já que não estão aceitando PR`s no repositório antigo