### PR TITLE
Adicionando compatibilidade com Laravel versão 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Laravel 6 - Validações em Português
+# Laravel 6+ - Validações em Português
 
 Esta é uma biblioteca com algumas validações brasileiras.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "laravellegends/pt-br-validator",
-    "description": "Uma biblioteca contendo validações de formatos Brasileiros, para o Laravel 5",
+    "description": "Uma biblioteca contendo validações de formatos Brasileiros, para o Laravel",
     "license" : "MIT",
     "authors": [
         {
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^6.0"
+        "illuminate/support": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +25,7 @@
     },
     "minimum-stability": "stable",
     "require-dev": {
-        "orchestra/testbench": "3.1.* || 4.0.*",
-        "phpunit/phpunit": "4.8.* || ^8.0"
+        "orchestra/testbench": "^4.0 || ^5.0",
+        "phpunit/phpunit": "^8.3 || ^9.0"
     }
 }


### PR DESCRIPTION
Adicionei compatibilidade com a versão 7 do Laravel e mantive a 6
Tive que alterar a versão do orchestra/testbench pra ficar de acordo com a tabela de compatibilidade da documentação deles.
Alterei também a versão do phpunit/phpunit pra ficar compatível com PHP >= 7.2 que já é requerido nas versões mais atuais do Laravel

Excelente lib, Wallace, obrigado. E espero ter ajudado.