### PR TITLE
Add Alphanumeric in CNPJ

### DIFF
--- a/src/pt-br-validator/Rules/Cnpj.php
+++ b/src/pt-br-validator/Rules/Cnpj.php
@@ -21,7 +21,7 @@ class Cnpj implements Rule
     */
     public function passes($attribute, $value)
     {
-        $c = preg_replace('/\D/', '', $value);
+        $c = preg_replace('/((?![0-9A-Z]).)/', '', strtoupper($value));
 
         $b = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
 
@@ -38,13 +38,13 @@ class Cnpj implements Rule
             return false;
         }
 
-        for ($i = 0, $n = 0; $i < 12; $n += $c[$i] * $b[++$i]);
+        for ($i = 0, $n = 0; $i < 12; $n += (ord($c[$i]) - 48) * $b[++$i]);
 
         if ($c[12] != ((($n %= 11) < 2) ? 0 : 11 - $n)) {
             return false;
         }
 
-        for ($i = 0, $n = 0; $i <= 12; $n += $c[$i] * $b[$i++]);
+        for ($i = 0, $n = 0; $i <= 12; $n += (ord($c[$i]) - 48) * $b[$i++]);
 
         if ($c[13] != ((($n %= 11) < 2) ? 0 : 11 - $n)) {
             return false;

--- a/src/pt-br-validator/Rules/FormatoCnpj.php
+++ b/src/pt-br-validator/Rules/FormatoCnpj.php
@@ -21,7 +21,7 @@ class FormatoCnpj implements Rule
     */
     public function passes($attribute, $value)
     {
-        return preg_match('/^\d{2}\.\d{3}\.\d{3}\/\d{4}-\d{2}$/', $value) > 0;
+        return preg_match('/^[0-9A-Z]{2}\.[0-9A-Z]{3}\.[0-9A-Z]{3}\/[0-9A-Z]{4}-\d{2}$/', $value) > 0;
     }
 
     public function message()

--- a/tests/TestRules.php
+++ b/tests/TestRules.php
@@ -127,7 +127,7 @@ class TestRules extends Orchestra\Testbench\TestCase
     public function testCnpj()
     {
         $validator = \Validator::make([
-            'valido' => '16.651.801/0001-57'
+            'valido' => '12.ABC.345/01DE-35'
         ], [
             'valido' => ['required', new \LaravelLegends\PtBrValidator\Rules\Cnpj]
         ]);
@@ -135,7 +135,7 @@ class TestRules extends Orchestra\Testbench\TestCase
         $this->assertTrue($validator->passes());
 
         $validator = \Validator::make([
-            'invalido' => '16.651.801/0001-52'
+            'invalido' => '12.ABC.345/01DE-36'
         ], [
             'invalido' => ['required', new \LaravelLegends\PtBrValidator\Rules\Cnpj]
         ]);
@@ -148,7 +148,7 @@ class TestRules extends Orchestra\Testbench\TestCase
     public function testFormatoCnpj()
     {
         $validator = \Validator::make([
-            'valido' => '16.651.801/0001-57'
+            'valido' => '12.ABC.345/01DE-35'
         ], [
             'valido' => ['required', new \LaravelLegends\PtBrValidator\Rules\FormatoCnpj]
         ]);
@@ -156,7 +156,7 @@ class TestRules extends Orchestra\Testbench\TestCase
         $this->assertTrue($validator->passes());
 
         $validator = \Validator::make([
-            'invalido' => '16.651.801/000152'
+            'invalido' => '12.ABC.345/01DE-36'
         ], [
             'invalido' => ['required', new \LaravelLegends\PtBrValidator\Rules\FormatoCnpj]
         ]);

--- a/tests/TestRules.php
+++ b/tests/TestRules.php
@@ -156,7 +156,7 @@ class TestRules extends Orchestra\Testbench\TestCase
         $this->assertTrue($validator->passes());
 
         $validator = \Validator::make([
-            'invalido' => '12.ABC.345/01DE-36'
+            'invalido' => '12.ABC.345/01DE36'
         ], [
             'invalido' => ['required', new \LaravelLegends\PtBrValidator\Rules\FormatoCnpj]
         ]);


### PR DESCRIPTION
From July 2026, the Receita Federal  will add letters and numbers to the CNPJ.

The old numbers are compatible with this calculation and I just added support for letters and numbers to the CPNJ.

Below is the PDF with the documentation for the new CNPJ issued by the Receita Federal

[calculodvcnpjalfanaumerico.pdf](https://github.com/user-attachments/files/17688623/calculodvcnpjalfanaumerico.pdf)
